### PR TITLE
feat: add daily Redis keep-alive cron

### DIFF
--- a/app/api/cron/redis-ping/route.ts
+++ b/app/api/cron/redis-ping/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { routeWrapper } from "@/backend/middlewares/RouteWrapper";
+import RedisClient from "@/lib/redis";
+import { envConfig } from "@/lib/envConfig";
+import type { Logger } from "@/lib/pino";
+
+const getHandler = async (req: NextRequest, _body: undefined, logger: Logger) => {
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${envConfig.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const client = await RedisClient.getClient();
+  const pong = await client.ping();
+  logger.info(`Redis keep-alive ping: ${pong}`);
+
+  return NextResponse.json({ isSuccess: true, pong });
+};
+
+export const GET = routeWrapper(getHandler);

--- a/lib/envConfig.ts
+++ b/lib/envConfig.ts
@@ -70,6 +70,9 @@ export class EnvConfig {
   public get REDIS_PORT() {
     return this.env.REDIS_PORT;
   }
+  public get CRON_SECRET() {
+    return this.env.CRON_SECRET;
+  }
 }
 
 export const envConfig = EnvConfig.getInstance();

--- a/schemas/common/Env.ts
+++ b/schemas/common/Env.ts
@@ -32,6 +32,9 @@ export const ZEnvSchema = z.object({
   REDIS_PASSWORD: z.string().min(1, "REDIS_PASSWORD is required"),
   REDIS_HOST: z.string().min(1, "REDIS_HOST is required"),
   REDIS_PORT: z.string().min(1, "REDIS_PORT is required"),
+
+  // Cron
+  CRON_SECRET: z.string().min(1, "CRON_SECRET is required"),
 });
 
 export type EnvSchema = z.infer<typeof ZEnvSchema>;

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,11 @@
   "framework": "nextjs",
   "buildCommand": "pnpm build",
   "devCommand": "pnpm dev",
-  "installCommand": "pnpm install"
+  "installCommand": "pnpm install",
+  "crons": [
+    {
+      "path": "/api/cron/redis-ping",
+      "schedule": "0 6 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
Redis Cloud free-tier instance was idle-expiring, breaking GitHub login via CallbackRouteError. Vercel Cron pings Redis once a day to keep the instance active.